### PR TITLE
Update store navigation item  test to match directions

### DIFF
--- a/tests/grader/5-store-acceptance-test.js
+++ b/tests/grader/5-store-acceptance-test.js
@@ -25,7 +25,7 @@ test('visiting /store', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/store', 'The URL is "/store"');
-    assert.equal(elementExists('#nav-link-store'), true, 'Brick template has a heading with ID "brick-heading".');
+    assert.equal(elementExists('#nav-link-store'), true, 'Store link in site navigation should have ID "nav-link-store".');
     assert.ok(canSeeLink('Cakes'), 'Can see the "Cakes" link.');
     assert.ok(canSeeLink('Cupcakes'), 'Can see the "Cupcakes" link.');
     assert.ok(canSeeLink('Cookies'), 'Can see the "Cookies" link.');


### PR DESCRIPTION
The direction states
* add a **"Store"** link to the site's navigation
  * have it load the store route
  * **give it the ID nav-link-store**

The  test is:
```
assert.equal(elementExists('#nav-link-store'), true, 'Brick template has a heading with ID "brick-heading".');
```

Notice the text referring to brick (assuming copy/paste error from earlier quiz).